### PR TITLE
Fix overloading bug in enum Action

### DIFF
--- a/Sources/SimplexArchitectureMacrosPlugin/Reducer/ReducerMacro+memberMacro.swift
+++ b/Sources/SimplexArchitectureMacrosPlugin/Reducer/ReducerMacro+memberMacro.swift
@@ -269,8 +269,25 @@ private extension [EnumCaseElementSyntax] {
         var counts: [String: Int] = [:]
 
         for item in self {
-            counts[item.trimmedDescription, default: 0] += 1
-            map[item.trimmedDescription] = item
+            if let parameterClause = item.parameterClause, parameterClause.parameters.compactMap(\.firstName).isEmpty 
+            {
+                /*
+                 public enum ViewAction {
+                     case increment
+                 }
+                 public enum ReducerAction {
+                     case increment(Int)
+                          ┬────────
+                          ╰─ 🛑 Cannot have duplicate cases in ViewAction and ReducerAction
+                 }
+                 */
+                let noAssociatedValueCase = item.with(\.parameterClause, nil)
+                counts[noAssociatedValueCase.trimmedDescription, default: 0] += 1
+                map[noAssociatedValueCase.trimmedDescription] = noAssociatedValueCase
+            } else {
+                counts[item.trimmedDescription, default: 0] += 1
+                map[item.trimmedDescription] = item
+            }
         }
 
         return counts.filter { $1 > 1 }.compactMap { map[$0.key] }

--- a/Tests/SimplexArchitectureTests/ReducerMacroTests.swift
+++ b/Tests/SimplexArchitectureTests/ReducerMacroTests.swift
@@ -128,6 +128,34 @@ final class ReducerMacroTests: XCTestCase {
             }
             """
         }
+
+        assertMacro {
+            """
+            @Reducer
+            public struct MyReducer {
+                public enum ViewAction {
+                    case increment
+                }
+                public enum ReducerAction {
+                    case increment(Int)
+                }
+            }
+            """
+        } matches: {
+            """
+            @Reducer
+            public struct MyReducer {
+                public enum ViewAction {
+                    case increment
+                }
+                public enum ReducerAction {
+                    case increment(Int)
+                         ┬────────
+                         ╰─ 🛑 Cannot have duplicate cases in ViewAction and ReducerAction
+                }
+            }
+            """
+        }
     }
 
     func testNotStruct() {


### PR DESCRIPTION
Fixed a bug that prevented the following code from producing Diagnostic

```Swift                
 public enum ViewAction {
     case increment
 }
 public enum ReducerAction {
     case increment(Int)
 }
 ```