### PR TITLE
Add `debounce(id:for:clock:)` to SideEffect

### DIFF
--- a/Examples/Github-App/Github-App/View/RepositoryView.swift
+++ b/Examples/Github-App/Github-App/View/RepositoryView.swift
@@ -33,7 +33,7 @@ struct RepositoryView: View {
 
     init(repository: Repository) {
         self.repository = repository
-        self.store = Store(
+        store = Store(
             reducer: RepositoryReducer(),
             initialReducerState: RepositoryReducer.ReducerState(url: repository.url)
         )

--- a/Examples/Github-App/Github-App/View/RootView.swift
+++ b/Examples/Github-App/Github-App/View/RootView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct RootReducer {
     enum ViewAction: Equatable {
         case textChanged
+        case onAppear
     }
 
     enum ReducerAction: Equatable {
@@ -26,6 +27,9 @@ struct RootReducer {
 
     func reduce(into state: StateContainer<RootView>, action: Action) -> SideEffect<Self> {
         switch action {
+        case .onAppear:
+            return fetchRepositories(query: "Swift")
+
         case .textChanged:
             if state.searchText.isEmpty {
                 state.repositories = []
@@ -116,6 +120,9 @@ struct RootView: View {
                 send(.textChanged)
             }
             .alert(target: self, unwrapping: $alertState)
+            .onAppear {
+                send(.onAppear)
+            }
         }
     }
 }

--- a/Examples/Github-App/Github-App/View/RootView.swift
+++ b/Examples/Github-App/Github-App/View/RootView.swift
@@ -18,7 +18,7 @@ struct RootReducer {
     }
 
     enum CancelID {
-        case fetchRequest
+        case response
     }
 
     @Dependency(\.repositoryClient.fetchRepositories) var fetchRepositories
@@ -33,8 +33,8 @@ struct RootReducer {
             } else {
                 return .send(.queryChangeDebounced)
                     .debounce(
-                        id: CancelID.fetchRequest,
-                        for: .seconds(0.3), 
+                        id: CancelID.response,
+                        for: .seconds(0.3),
                         clock: clock
                     )
             }

--- a/Examples/Github-App/Github-App/View/RootView.swift
+++ b/Examples/Github-App/Github-App/View/RootView.swift
@@ -4,32 +4,47 @@ import SwiftUI
 @Reducer
 struct RootReducer {
     enum ViewAction: Equatable {
-        case onSearchButtonTapped
-        case onTextChanged(String)
+        case textChanged
     }
 
     enum ReducerAction: Equatable {
         case fetchRepositoriesResponse(TaskResult<[Repository]>)
         case alert(Alert)
+        case queryChangeDebounced
 
         enum Alert: Equatable {
             case retry
         }
     }
 
+    enum CancelID {
+        case fetchRequest
+    }
+
     @Dependency(\.repositoryClient.fetchRepositories) var fetchRepositories
+    @Dependency(\.continuousClock) var clock
 
     func reduce(into state: StateContainer<RootView>, action: Action) -> SideEffect<Self> {
         switch action {
-        case .onSearchButtonTapped:
+        case .textChanged:
+            if state.searchText.isEmpty {
+                state.repositories = []
+                return .none
+            } else {
+                return .send(.queryChangeDebounced)
+                    .debounce(
+                        id: CancelID.fetchRequest,
+                        for: .seconds(0.3), 
+                        clock: clock
+                    )
+            }
+
+        case .queryChangeDebounced:
+            guard !state.searchText.isEmpty else {
+                return .none
+            }
             state.isLoading = true
             return fetchRepositories(query: state.searchText)
-
-        case let .onTextChanged(text):
-            if text.isEmpty {
-                state.repositories = []
-            }
-            return .none
 
         case let .fetchRepositoriesResponse(.success(repositories)):
             state.isLoading = false
@@ -93,12 +108,12 @@ struct RootView: View {
                     ProgressView()
                 }
             }
-            .searchable(text: $searchText)
-            .onSubmit(of: .search) {
-                send(.onSearchButtonTapped)
-            }
-            .onChange(of: searchText) { _, newValue in
-                send(.onTextChanged(newValue))
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer
+            )
+            .onChange(of: searchText) { _, _ in
+                send(.textChanged)
             }
             .alert(target: self, unwrapping: $alertState)
         }

--- a/Sources/SimplexArchitecture/SideEffect.swift
+++ b/Sources/SimplexArchitecture/SideEffect.swift
@@ -18,9 +18,11 @@ public struct SideEffect<Reducer: ReducerProtocol>: Sendable {
         case concurrentAction([Reducer.Action])
         case serialEffect([SideEffect<Reducer>])
         case concurrentEffect([SideEffect<Reducer>])
+        indirect case debounce(base: Self, id: AnyHashable, sleep: () async throws -> Void)
     }
 
     // The kind of side effect.
+    @usableFromInline
     let kind: EffectKind
 
     @usableFromInline
@@ -116,5 +118,30 @@ public extension SideEffect {
     @inlinable
     static func concurrent(_ effects: SideEffect<Reducer>...) -> Self {
         .init(effectKind: .concurrentEffect(effects))
+    }
+}
+
+public extension SideEffect {
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    @inlinable
+    func debounce(
+        id: some Hashable,
+        for duration: Duration,
+        clock: any Clock<Duration>
+    ) -> Self {
+        switch self.kind {
+        case .none, .debounce:
+            self
+        default:
+            .init(
+                effectKind: .debounce(
+                    base: self.kind,
+                    id: AnyHashable(id),
+                    sleep: {
+                        try await clock.sleep(for: duration)
+                    }
+                )
+            )
+        }
     }
 }

--- a/Sources/SimplexArchitecture/SideEffect.swift
+++ b/Sources/SimplexArchitecture/SideEffect.swift
@@ -129,13 +129,13 @@ public extension SideEffect {
         for duration: Duration,
         clock: any Clock<Duration>
     ) -> Self {
-        switch self.kind {
+        switch kind {
         case .none, .debounce:
             self
         default:
             .init(
                 effectKind: .debounce(
-                    base: self.kind,
+                    base: kind,
                     id: AnyHashable(id),
                     sleep: {
                         try await clock.sleep(for: duration)

--- a/Sources/SimplexArchitecture/SideEffect.swift
+++ b/Sources/SimplexArchitecture/SideEffect.swift
@@ -122,6 +122,16 @@ public extension SideEffect {
 }
 
 public extension SideEffect {
+    /// Turns an side effect into one that can be debounced.
+    ///
+    /// debounce is an operator that plays only the last event in a sequence of SideEffects that have been issued for more than a certain time interval.
+    /// To turn an effect into a debounce-able one you must provide an identifier, which is used to determine which in-flight effect should be canceled in order to start a new effect.
+    ///
+    /// - Parameters:
+    ///   - id: The effect's identifier.
+    ///   - duration: The duration you want to debounce for.
+    ///   - clock: A clock conforming to the `Clock` protocol, used to measure the passing of time for the debounce duration.
+    /// - Returns: A debounced version of the effect.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @inlinable
     func debounce(

--- a/Sources/SimplexArchitecture/Store/Store+send.swift
+++ b/Sources/SimplexArchitecture/Store/Store+send.swift
@@ -197,7 +197,7 @@ extension Store {
 
         case let .debounce(base, id, sleep):
             cancellableTasks[id]?.cancel()
-            let cancellableTask =  Task.withEffectContext {
+            let cancellableTask = Task.withEffectContext {
                 try? await sleep()
                 guard !Task.isCancelled else { return }
                 await reduce(tasks: runEffect(base, send: send)).wait()

--- a/Sources/SimplexArchitecture/Store/Store+send.swift
+++ b/Sources/SimplexArchitecture/Store/Store+send.swift
@@ -199,7 +199,9 @@ extension Store {
             cancellableTasks[id]?.cancel()
             let cancellableTask = Task.withEffectContext {
                 try? await sleep()
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else {
+                    return
+                }
                 await reduce(tasks: runEffect(base, send: send)).wait()
             }
             cancellableTasks.updateValue(cancellableTask, forKey: id)

--- a/Sources/SimplexArchitecture/Store/Store+send.swift
+++ b/Sources/SimplexArchitecture/Store/Store+send.swift
@@ -91,7 +91,7 @@ extension Store {
             return .never
         } else {
             let send = _send ?? makeSend(for: container)
-            let tasks = runEffect(sideEffect, send: send)
+            let tasks = runEffect(sideEffect.kind, send: send)
 
             return reduce(tasks: tasks)
         }
@@ -128,10 +128,10 @@ extension Store {
     }
 
     func runEffect(
-        _ sideEffect: borrowing SideEffect<Reducer>,
+        _ sideEffect: SideEffect<Reducer>.EffectKind,
         send: Send<Reducer>
     ) -> [SendTask] {
-        switch sideEffect.kind {
+        switch sideEffect {
         case let .run(priority, operation, `catch`):
             let task = Task.withEffectContext(priority: priority ?? .medium) {
                 do {
@@ -179,7 +179,7 @@ extension Store {
         case let .serialEffect(effects):
             let task = Task.detached {
                 for effect in effects {
-                    await self.reduce(tasks: self.runEffect(effect, send: send)).wait()
+                    await self.reduce(tasks: self.runEffect(effect.kind, send: send)).wait()
                 }
             }
             return [SendTask(task: task)]
@@ -189,11 +189,21 @@ extension Store {
                 partialResult.append(
                     SendTask(
                         task: Task.detached {
-                            await self.reduce(tasks: self.runEffect(effect, send: send)).wait()
+                            await self.reduce(tasks: self.runEffect(effect.kind, send: send)).wait()
                         }
                     )
                 )
             }
+
+        case let .debounce(base, id, sleep):
+            cancellableTasks[id]?.cancel()
+            let cancellableTask =  Task.withEffectContext {
+                try? await sleep()
+                guard !Task.isCancelled else { return }
+                await reduce(tasks: runEffect(base, send: send)).wait()
+            }
+            cancellableTasks.updateValue(cancellableTask, forKey: id)
+            return [SendTask(task: cancellableTask)]
 
         case .none:
             return []

--- a/Sources/SimplexArchitectureMacrosPlugin/Reducer/ReducerMacro+memberMacro.swift
+++ b/Sources/SimplexArchitectureMacrosPlugin/Reducer/ReducerMacro+memberMacro.swift
@@ -72,7 +72,7 @@ public struct ReducerMacro: MemberMacro {
                     name: .identifier("Action"),
                     inheritanceClause: InheritanceClauseSyntax {
                         (viewAction.inheritanceClause?.inheritedTypes ?? []) +
-                        [InheritedTypeSyntax(type: TypeSyntax(stringLiteral: "ActionProtocol"))]
+                            [InheritedTypeSyntax(type: TypeSyntax(stringLiteral: "ActionProtocol"))]
                     }
                 ) {
                     MemberBlockItemListSyntax {
@@ -92,7 +92,7 @@ public struct ReducerMacro: MemberMacro {
                         reducerActionToAction
                     }
                 }
-                    .formatted().cast(EnumDeclSyntax.self)
+                .formatted().cast(EnumDeclSyntax.self)
             ).formatted().cast(DeclSyntax.self),
         ].compactMap { $0 }
     }
@@ -204,16 +204,16 @@ public struct ReducerMacro: MemberMacro {
     private static func changeAnyNestedDeclToTypealias(action: EnumDeclSyntax, reducerAccessModifier: String) -> EnumDeclSyntax {
         action.with(
             \.memberBlock,
-             action.memberBlock.with(
+            action.memberBlock.with(
                 \.members,
-                 MemberBlockItemListSyntax(
+                MemberBlockItemListSyntax(
                     action.memberBlock.members.compactMap {
                         if let name = $0.hasName?.name.text,
                            !name.contains(action.name.text)
                         {
                             $0.with(
                                 \.decl,
-                                 DeclSyntax(
+                                DeclSyntax(
                                     TypeAliasDeclSyntax(
                                         modifiers: .init(arrayLiteral: DeclModifierSyntax(name: .identifier(reducerAccessModifier))),
                                         name: .identifier(name),
@@ -221,16 +221,16 @@ public struct ReducerMacro: MemberMacro {
                                             value: IdentifierTypeSyntax(name: .identifier("\(action.name.text).\(name)"))
                                         )
                                     )
-                                 )
+                                )
                             )
                         } else {
                             $0
                         }
                     }
-                 )
-             )
-             .formatted()
-             .cast(MemberBlockSyntax.self)
+                )
+            )
+            .formatted()
+            .cast(MemberBlockSyntax.self)
         )
     }
 

--- a/Tests/SimplexArchitectureTests/StoreTests.swift
+++ b/Tests/SimplexArchitectureTests/StoreTests.swift
@@ -241,3 +241,13 @@ private struct TestView: View {
         EmptyView()
     }
 }
+
+extension Store {
+    @_disfavoredOverload
+    func runEffect(
+        _ sideEffect: SideEffect<Reducer>,
+        send: Send<Reducer>
+    ) -> [SendTask] {
+        runEffect(sideEffect.kind, send: send)
+    }
+}

--- a/Tests/SimplexArchitectureTests/StoreTests.swift
+++ b/Tests/SimplexArchitectureTests/StoreTests.swift
@@ -69,13 +69,27 @@ final class StoreTests: XCTestCase {
 
         let sendTasks7 = store.runEffect(.serial(.c3, .c4), send: send)
         XCTAssertEqual(sendTasks7.count, 1)
-        XCTAssertNotNil(sendTasks5.first?.task)
+        XCTAssertNotNil(sendTasks7.first?.task)
 
         let sendTasks8 = store.runEffect(.concurrent(.c3, .c4), send: send)
         XCTAssertEqual(sendTasks8.count, 2)
         for task in sendTasks8.map(\.task) {
             XCTAssertNotNil(task)
         }
+
+        let sendTasks9 = store.runEffect(.serial(.send(.c1), .send(.c2)), send: send)
+        XCTAssertEqual(sendTasks9.count, 1)
+        XCTAssertNotNil(sendTasks9.first?.task)
+
+        let sendTasks10 = store.runEffect(.concurrent(.send(.c1), .send(.c2)), send: send)
+        XCTAssertEqual(sendTasks10.count, 2)
+        for task in sendTasks10.map(\.task) {
+            XCTAssertNotNil(task)
+        }
+
+        let sendTasks11 = store.runEffect(.send(.c1).debounce(id: "test", for: .seconds(0.3), clock: ImmediateClock()), send: send)
+        XCTAssertEqual(sendTasks11.count, 1)
+        XCTAssertNotNil(sendTasks11.first?.task)
     }
 
     func testSendAction() async throws {


### PR DESCRIPTION
debounce is an operator that plays only the last event in a sequence of SideEffects that have been issued for more than a certain time interval.

```swift
return .send(.queryChangeDebounced)
    .debounce(
        id: CancelID.response,
        for: .seconds(0.3), 
        clock: clock
    )
```